### PR TITLE
Finish basics for abstract Trivia and mixins

### DIFF
--- a/wentrivia/__init__.py
+++ b/wentrivia/__init__.py
@@ -1,3 +1,1 @@
-from .trivia import Trivia # noqa
-
-__version__ = "0.1"
+__version__ = "0.0.3"

--- a/wentrivia/abc_trivia.py
+++ b/wentrivia/abc_trivia.py
@@ -1,0 +1,181 @@
+from abc import ABC, abstractmethod
+import asyncio
+from collections import defaultdict
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+import json
+from operator import itemgetter
+from pathlib import Path
+import random
+import typing as t
+
+
+from discord import User, Message  # type: ignore
+from discord.ext.commands import Context  # type: ignore
+
+
+@dataclass
+class Question:
+    """
+    This class describes a question with the following fields:
+
+    - `content`: the question or hint to be shown.
+    - `points`: how many points answering correctly grants.
+    - `answers`: correct answers to the question, to display.
+    - `lowercase_answers`: correct answers in lowercase, to compare.
+    """
+    content: str = 'Not set'
+    points: int = 0
+    answers: t.Tuple[str, ...] = field(default_factory=tuple)
+    lowercase_answers: t.Tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.answers and not self.lowercase_answers:
+            self.lowercase_answers = tuple(a.lower() for a in self.answers)
+
+
+@dataclass
+class ForgivingQuestion(Question):
+    """
+    A question that might not require a perfect answer to consider it valid.
+    When set to true, `perfect` indicates that the answers must be a perfect
+    match.
+    """
+    perfect: bool = False
+
+
+class ABCTrivia(ABC):
+    """Base class to combine with mixins and make Trivia games."""
+    def __init__(
+            self,
+            ctx: Context,
+            category='',
+            factory: t.Callable[..., t.Any] = Question,
+    ) -> None:
+        self.ctx = ctx
+        self.playing = False
+        self.questions_pool: t.List[Question] = []
+        self.category = category
+        self.scores: t.DefaultDict[User, int] = defaultdict(int)
+        self.factory = factory
+
+    async def __aenter__(self) -> 'ABCTrivia':
+        self.playing = True
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+        self.playing = False
+
+    @abstractmethod
+    def check_answer(self, message: t.Any, question: t.Any) -> bool:
+        """Checks if an answer is correct, comparing it to the question."""
+
+    @abstractmethod
+    def load_questions(self, *, category='', k=2) -> None:
+        """Loads questions. Override to load them and refer to them in
+        `self.questions_pool"""
+
+    @abstractmethod
+    async def start(self, *args, **kwargs):
+        """Starts the game."""
+
+
+class JSONLoaderMixin(ABCTrivia):
+    def load_questions(self, *, category='', k=2) -> None:
+        """
+        Loads questions and shuffles them, with an optional `lang` argument,
+        from a file named `questions.{lang}.json`.
+        """
+        filename = (
+            'questions' +
+            (f'.{category}.json' if category else '.json')
+        )
+
+        with open(Path(__file__).parent / filename) as file:
+            questions = json.load(file)['questions']
+
+        len_range = range(len(questions))
+        number = min(len(questions), k)
+
+        chosen_index = (
+            random.sample(len_range, k=number)
+            + random.choices(len_range, k=k-number)
+        )
+
+        self.questions_pool = [
+            self.factory(**questions[n])
+            for n in chosen_index
+        ]
+
+
+class ForgivingCheckerMixin(ABCTrivia):
+    def __init__(self, forgiveness_ratio=0.0, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.factory = ForgivingQuestion
+        self.__ratio = forgiveness_ratio
+
+    def check_answer(
+            self,
+            message: t.Union[str, Message],
+            question: ForgivingQuestion
+    ) -> bool:
+        """Checks if the given `answer` matches any correct answer to
+        the `question`"""
+        if isinstance(message, Message):
+            answer = message.content.lower()
+        else:
+            answer = message.lower()
+
+        correct_answers = question.lowercase_answers
+
+        if question.perfect:
+            return answer in correct_answers
+
+        return any(
+            SequenceMatcher(a=answer, b=correct).quick_ratio() > self.__ratio
+            for correct in correct_answers
+        )
+
+
+class RegularLogicMixin(ABCTrivia):
+    """
+    Trivia mixin to have a regular competitive logic: only the first one who
+    answers gets the points for a given question.
+    """
+    async def _play(self, **kwargs) -> None:  # type: ignore
+        """Game logic."""
+        async with self:
+            self.load_questions(**kwargs)
+            await self.ctx.send('Comenzando partida!')
+
+            for question in self.questions_pool:
+                await self.ctx.send(question)
+                try:
+                    msg: Message = await self.ctx.bot.wait_for(
+                        'message', timeout=15,
+                        check=lambda msg: self.check_answer(msg, question)
+                    )
+                    self.scores[msg.author] += question.points
+                    await self.ctx.send(f'{msg.author} acertó! +{question.points} puntos')
+
+                except asyncio.TimeoutError:
+                    await self.ctx.send('Nadie contestó')
+
+            if self.scores:
+                scores = sorted(
+                    self.scores.items(),
+                    key=itemgetter(1),
+                    reverse=True
+                )
+                await self.ctx.send('\n'.join(f'{p.name}: {s} puntos' for p, s in scores))
+            else:
+                await self.ctx.send('Nadie acertó nada')
+
+    async def start(self, *args, **loader_kwargs) -> None:
+        """Starts the game"""
+        await self._play(**loader_kwargs)
+
+
+class ForgivingTrivia(RegularLogicMixin, ForgivingCheckerMixin, JSONLoaderMixin):
+    def __init__(self, ctx: Context):
+        super().__init__(ctx=ctx)

--- a/wentrivia/abc_trivia.py
+++ b/wentrivia/abc_trivia.py
@@ -1,3 +1,10 @@
+"""
+Module to build trivia configurations.
+
+Every game is expected to be built with the type `Question` or any subtype,
+and any implementation of the `ABCTrivia` class.
+"""
+
 from abc import ABC, abstractmethod
 import asyncio
 from collections import defaultdict
@@ -81,7 +88,7 @@ class ABCTrivia(ABC):
 
 
 class JSONLoaderMixin(ABCTrivia):
-    def load_questions(self, *, category='', k=2) -> None:
+    def load_questions(self, *, category='', k=10) -> None:
         """
         Loads questions and shuffles them, with an optional `lang` argument,
         from a file named `questions.{lang}.json`.
@@ -109,7 +116,7 @@ class JSONLoaderMixin(ABCTrivia):
 
 
 class ForgivingCheckerMixin(ABCTrivia):
-    def __init__(self, forgiveness_ratio=0.0, *args, **kwargs):
+    def __init__(self, *args, forgiveness_ratio=0.8, **kwargs):
         super().__init__(*args, **kwargs)
         self.factory = ForgivingQuestion
         self.__ratio = forgiveness_ratio
@@ -174,8 +181,3 @@ class RegularLogicMixin(ABCTrivia):
     async def start(self, *args, **loader_kwargs) -> None:
         """Starts the game"""
         await self._play(**loader_kwargs)
-
-
-class ForgivingTrivia(RegularLogicMixin, ForgivingCheckerMixin, JSONLoaderMixin):
-    def __init__(self, ctx: Context):
-        super().__init__(ctx=ctx)

--- a/wentrivia/trivia.py
+++ b/wentrivia/trivia.py
@@ -1,141 +1,23 @@
 """
-Main module for trivia games.
+Module for premade trivia configurations.
 
-Trivia games can be created with the `Trivia` class, passing it a discord.py
-context object as the first argument. This module does not count with locking
+Trivia games can be created with any of the trivia classe in this module,
+passing it at least a discord.py context object. They do not count with locking
 mechanisms to make sure there's a single game per channel, it only handles the
 game's internal logic.
 
 Example:
 
->>> game = Trivia(ctx)
->>> game.play()
+>>> game = RegularTrivia(ctx)
+>>> await game.start()
 """
 
-import asyncio
-from collections import defaultdict
-from difflib import SequenceMatcher
-from dataclasses import dataclass
-import json
-from operator import itemgetter
-from pathlib import Path
-import random
-from typing import Tuple, DefaultDict, List, Union
-
-from discord import User, Message
-from discord.ext.commands import Context
+import wentrivia.abc_trivia as abct
 
 
-@dataclass
-class Question:
-    """
-    This class describes a question with the following fields:
-
-    - `content`: the question or hint to be shown.
-    - `points`: how many points answering correctly grants.
-    - `answers`: correct answers to the question.
-    - `perfect`: if `True`, the answer will only be considered correct if it's
-       a perfect match
-    """
-    content: str
-    points: int
-    answers: Tuple[str, ...]
-    perfect: bool = False
-
-
-class Trivia:
-    """
-    Class with the logic for a trivia game.
-
-    Each game should spawn an indiviual `Trivia` instance. This allows having
-    multiple games running at the same time.
-    """
-    def __init__(self, ctx: Context, lang='') -> None:
-        self.ctx = ctx
-        self.playing = False
-        self.questions_pool: List[Question] = []
-        self.language = lang
-        self.scores: DefaultDict[User, int] = defaultdict(int)
-
-    async def __aenter__(self) -> 'Trivia':
-        self.playing = True
-        return self
-
-    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
-        self.scores.clear()
-        self.playing = False
-
-    @staticmethod
-    def check_answer(message: Union[str, Message], question: Question) -> bool:
-        """Checks if the given `answer` matches any correct answer to
-        the `question`"""
-        if isinstance(message, Message):
-            answer = message.content.casefold()
-        else:
-            answer = message.casefold()
-
-        # TODO: This should be somewhere else. It's being generated each time.
-        correct_answers = (correct.casefold() for correct in question.answers)
-
-        if question.perfect:
-            return answer in correct_answers
-
-        return any(
-            SequenceMatcher(a=answer, b=correct).quick_ratio() > 0.8
-            for correct in correct_answers
-        )
-
-    def load_questions(self, lang='', k=2) -> None:
-        """
-        Loads questions and shuffles them, with an optional `lang` argument,
-        from a file named `questions.{lang}.json`.
-        """
-        filename = (
-            'questions' +
-            (f'.{lang}.json' if lang else '.json')
-        )
-
-        # it might be wise to run this from an `Executor`, but the time
-        # it blocks is negligible for now
-        with open(Path(__file__).parent / filename) as file:
-            questions = json.load(file)['questions']
-
-        len_range = range(len(questions))
-        number = min(len(questions), k)
-
-        chosen_index = (
-            random.sample(len_range, k=number)
-            + random.choices(len_range, k=k-number)
-        )
-
-        self.questions_pool = [
-            Question(**questions[n])
-            for n in chosen_index
-        ]
-
-    async def play(self) -> None:
-        """Game logic."""
-        async with self:
-            await self.ctx.send('Comenzando partida!')
-            self.load_questions()
-
-            for question in self.questions_pool:
-                await self.ctx.send(question)
-                try:
-                    msg: Message = await self.ctx.bot.wait_for(
-                        'message', timeout=15,
-                        check=lambda msg: self.check_answer(msg, question)
-                    )
-                    self.scores[msg.author] += question.points
-                    await self.ctx.send(f'{msg.author} acertó! +{question.points} puntos')
-                except asyncio.TimeoutError:
-                    await self.ctx.send('Nadie contestó')
-            if self.scores:
-                scores = sorted(
-                    self.scores.items(),
-                    key=itemgetter(1),
-                    reverse=True
-                )
-                await self.ctx.send('\n'.join(f'{p.name}: {s} puntos' for p, s in scores))
-            else:
-                await self.ctx.send('Nadie acertó nada')
+class RegularTrivia(
+        abct.RegularLogicMixin,
+        abct.ForgivingCheckerMixin,
+        abct.JSONLoaderMixin
+        ):
+    pass

--- a/wentrivia/trivia_cog.py
+++ b/wentrivia/trivia_cog.py
@@ -2,7 +2,7 @@ from typing import Dict
 from discord.ext.commands import Context, Cog
 from discord.ext import commands
 
-from .trivia import Trivia
+from .trivia import RegularTrivia
 
 
 class TriviaCog(Cog):
@@ -10,7 +10,7 @@ class TriviaCog(Cog):
     can games be started in, and how many can be played concurrently."""
     def __init__(self, bot: commands.bot.Bot):
         self.bot = bot
-        self.games: Dict[int, Trivia] = {}
+        self.games: Dict[int, RegularTrivia] = {}
         self.channels = [627959873329430570]
 
     @commands.command()
@@ -24,7 +24,7 @@ class TriviaCog(Cog):
         if not can_start:
             return
 
-        game = Trivia(ctx)
+        game = RegularTrivia(ctx=ctx)
         self.games[ctx.channel.id] = game
-        await game.play()
+        await game.start()
         del self.games[ctx.channel.id]


### PR DESCRIPTION
The `trivia` module now is reserved for prebuilt trivia configurations. For now, there's just one, `RegularTrivia`.

The `abc_trivia` module offers some mixins to build a Trivia.

Changes are expected. It's already possible to play games, but the library is still fairly and far from its goal, so the questions are still sent as the basic dataclass `__repr__` and the channel id for the games is still hardcoded.